### PR TITLE
Rebuild search backend in Go with concurrent meta-search providers

### DIFF
--- a/GO_BACKEND.md
+++ b/GO_BACKEND.md
@@ -1,0 +1,31 @@
+# Go Backend Architecture
+
+## Structure
+
+- `cmd/server/main.go`: composition root and HTTP server bootstrap.
+- `internal/api`: HTTP handlers and request/response plumbing.
+- `internal/service`: orchestration for meta-search aggregation + ranking hooks.
+- `internal/provider`: provider adapters (DuckDuckGo, Wikipedia, GitHub).
+- `internal/models`: shared domain models.
+- `internal/crawler`: crawler extension-point stubs.
+- `internal/index`: indexing extension-point stubs.
+- `internal/config`: environment-based configuration loader.
+
+## Runtime flow
+
+1. `GET /search?q=...` hits API handler.
+2. Handler validates input and attaches request/provider timeouts through context.
+3. `SearchService` fan-outs provider searches concurrently using goroutines + `sync.WaitGroup`.
+4. Aggregated results are deduplicated by URL, scored with a simple ranking heuristic, then returned as JSON.
+5. Future ranking, crawler, and index layers can be injected without rewriting API/provider layers.
+
+## Environment variables
+
+- `PORT` (default `8080`)
+- `REQUEST_TIMEOUT` (default `8s`)
+- `PROVIDER_TIMEOUT` (default `4s`)
+- `MAX_RESULTS_PER_PROVIDER` (default `5`)
+- `DUCKDUCKGO_BASE_URL` (default `https://api.duckduckgo.com`)
+- `WIKIPEDIA_BASE_URL` (default `https://en.wikipedia.org`)
+- `GITHUB_BASE_URL` (default `https://api.github.com`)
+- `GITHUB_TOKEN` (optional; improves GitHub API limits)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"kshanik_search/internal/api"
+	"kshanik_search/internal/config"
+	"kshanik_search/internal/provider"
+	"kshanik_search/internal/service"
+)
+
+func main() {
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+
+	httpClient := &http.Client{Timeout: cfg.ProviderTimeout}
+	providers := []provider.SearchProvider{
+		provider.NewDuckDuckGoProvider(httpClient, cfg.DuckDuckGoURL, cfg.MaxResults),
+		provider.NewWikipediaProvider(httpClient, cfg.WikipediaURL, cfg.MaxResults),
+		provider.NewGitHubProvider(httpClient, cfg.GitHubURL, cfg.MaxResults, cfg.GitHubToken),
+	}
+
+	searchService := service.NewSearchService(providers)
+	handler := api.NewHandler(searchService, cfg.RequestTimeout, cfg.ProviderTimeout)
+
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	server := &http.Server{
+		Addr:              ":" + cfg.Port,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	log.Printf("search API listening on :%s", cfg.Port)
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("server failed: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module kshanik_search
+
+go 1.22

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"kshanik_search/internal/service"
+)
+
+type Handler struct {
+	searchService   *service.SearchService
+	requestTimeout  time.Duration
+	providerTimeout time.Duration
+}
+
+func NewHandler(searchService *service.SearchService, requestTimeout, providerTimeout time.Duration) *Handler {
+	return &Handler{searchService: searchService, requestTimeout: requestTimeout, providerTimeout: providerTimeout}
+}
+
+func (h *Handler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /search", h.search)
+}
+
+func (h *Handler) search(w http.ResponseWriter, r *http.Request) {
+	query := strings.TrimSpace(r.URL.Query().Get("q"))
+	if query == "" {
+		h.writeError(w, http.StatusBadRequest, "missing q query parameter")
+		return
+	}
+
+	requestCtx, cancel := context.WithTimeout(r.Context(), h.requestTimeout)
+	defer cancel()
+	providerCtx, cancelProviders := context.WithTimeout(requestCtx, h.providerTimeout)
+	defer cancelProviders()
+
+	results, err := h.searchService.Search(providerCtx, query)
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(results); err != nil {
+		h.writeError(w, http.StatusInternalServerError, err.Error())
+	}
+}
+
+func (h *Handler) writeError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+type Config struct {
+	Port            string
+	RequestTimeout  time.Duration
+	ProviderTimeout time.Duration
+	MaxResults      int
+	DuckDuckGoURL   string
+	WikipediaURL    string
+	GitHubURL       string
+	GitHubToken     string
+}
+
+func Load() (Config, error) {
+	requestTimeout, err := durationFromEnv("REQUEST_TIMEOUT", 8*time.Second)
+	if err != nil {
+		return Config{}, err
+	}
+	providerTimeout, err := durationFromEnv("PROVIDER_TIMEOUT", 4*time.Second)
+	if err != nil {
+		return Config{}, err
+	}
+	maxResults, err := intFromEnv("MAX_RESULTS_PER_PROVIDER", 5)
+	if err != nil {
+		return Config{}, err
+	}
+
+	return Config{
+		Port:            stringFromEnv("PORT", "8080"),
+		RequestTimeout:  requestTimeout,
+		ProviderTimeout: providerTimeout,
+		MaxResults:      maxResults,
+		DuckDuckGoURL:   stringFromEnv("DUCKDUCKGO_BASE_URL", "https://api.duckduckgo.com"),
+		WikipediaURL:    stringFromEnv("WIKIPEDIA_BASE_URL", "https://en.wikipedia.org"),
+		GitHubURL:       stringFromEnv("GITHUB_BASE_URL", "https://api.github.com"),
+		GitHubToken:     os.Getenv("GITHUB_TOKEN"),
+	}, nil
+}
+
+func stringFromEnv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func intFromEnv(key string, fallback int) (int, error) {
+	if v := os.Getenv(key); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil {
+			return 0, fmt.Errorf("invalid %s: %w", key, err)
+		}
+		return parsed, nil
+	}
+	return fallback, nil
+}
+
+func durationFromEnv(key string, fallback time.Duration) (time.Duration, error) {
+	if v := os.Getenv(key); v != "" {
+		parsed, err := time.ParseDuration(v)
+		if err != nil {
+			return 0, fmt.Errorf("invalid %s: %w", key, err)
+		}
+		return parsed, nil
+	}
+	return fallback, nil
+}

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -1,0 +1,8 @@
+package crawler
+
+import "context"
+
+// Crawler is a future extension point for web crawling and document extraction.
+type Crawler interface {
+	Crawl(ctx context.Context, seeds []string) error
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -1,0 +1,9 @@
+package index
+
+import "context"
+
+// Index is a future extension point for inverted index + vector store.
+type Index interface {
+	AddDocument(ctx context.Context, id string, content string) error
+	Search(ctx context.Context, query string, limit int) ([]string, error)
+}

--- a/internal/models/search_result.go
+++ b/internal/models/search_result.go
@@ -1,0 +1,13 @@
+package models
+
+import "time"
+
+// SearchResult is the normalized result shape returned by all providers.
+type SearchResult struct {
+	Title     string    `json:"title"`
+	Snippet   string    `json:"snippet"`
+	URL       string    `json:"url"`
+	Source    string    `json:"source"`
+	Score     float64   `json:"score"`
+	Timestamp time.Time `json:"timestamp"`
+}

--- a/internal/provider/duckduckgo.go
+++ b/internal/provider/duckduckgo.go
@@ -1,0 +1,95 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"kshanik_search/internal/models"
+)
+
+type DuckDuckGoProvider struct {
+	client     *http.Client
+	baseURL    string
+	maxResults int
+}
+
+func NewDuckDuckGoProvider(client *http.Client, baseURL string, maxResults int) *DuckDuckGoProvider {
+	return &DuckDuckGoProvider{client: client, baseURL: baseURL, maxResults: maxResults}
+}
+
+func (p *DuckDuckGoProvider) Name() string { return "duckduckgo" }
+
+type duckduckgoResponse struct {
+	Heading       string `json:"Heading"`
+	AbstractText  string `json:"AbstractText"`
+	AbstractURL   string `json:"AbstractURL"`
+	RelatedTopics []struct {
+		Text     string `json:"Text"`
+		FirstURL string `json:"FirstURL"`
+		Topics   []struct {
+			Text     string `json:"Text"`
+			FirstURL string `json:"FirstURL"`
+		} `json:"Topics"`
+	} `json:"RelatedTopics"`
+}
+
+func (p *DuckDuckGoProvider) Search(ctx context.Context, query string) ([]models.SearchResult, error) {
+	endpoint := fmt.Sprintf("%s/?q=%s&format=json&no_html=1&skip_disambig=1", p.baseURL, url.QueryEscape(query))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("duckduckgo build request: %w", err)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("duckduckgo request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("duckduckgo unexpected status: %d", resp.StatusCode)
+	}
+
+	var payload duckduckgoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("duckduckgo decode: %w", err)
+	}
+
+	results := make([]models.SearchResult, 0, p.maxResults)
+	now := time.Now().UTC()
+
+	if payload.AbstractURL != "" {
+		results = append(results, models.SearchResult{
+			Title:     payload.Heading,
+			Snippet:   payload.AbstractText,
+			URL:       payload.AbstractURL,
+			Source:    p.Name(),
+			Timestamp: now,
+		})
+	}
+
+	for _, topic := range payload.RelatedTopics {
+		if len(results) >= p.maxResults {
+			break
+		}
+		if topic.FirstURL != "" {
+			results = append(results, models.SearchResult{Title: topic.Text, Snippet: topic.Text, URL: topic.FirstURL, Source: p.Name(), Timestamp: now})
+			continue
+		}
+		for _, nested := range topic.Topics {
+			if len(results) >= p.maxResults {
+				break
+			}
+			if nested.FirstURL == "" {
+				continue
+			}
+			results = append(results, models.SearchResult{Title: nested.Text, Snippet: nested.Text, URL: nested.FirstURL, Source: p.Name(), Timestamp: now})
+		}
+	}
+
+	return results, nil
+}

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -1,0 +1,75 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"kshanik_search/internal/models"
+)
+
+type GitHubProvider struct {
+	client     *http.Client
+	baseURL    string
+	maxResults int
+	token      string
+}
+
+func NewGitHubProvider(client *http.Client, baseURL string, maxResults int, token string) *GitHubProvider {
+	return &GitHubProvider{client: client, baseURL: baseURL, maxResults: maxResults, token: token}
+}
+
+func (p *GitHubProvider) Name() string { return "github" }
+
+type githubSearchResponse struct {
+	Items []struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		HTMLURL     string `json:"html_url"`
+	} `json:"items"`
+}
+
+func (p *GitHubProvider) Search(ctx context.Context, query string) ([]models.SearchResult, error) {
+	endpoint := fmt.Sprintf("%s/search/repositories?q=%s&per_page=%d", p.baseURL, url.QueryEscape(query), p.maxResults)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("github build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "kshanik-search-go")
+	if p.token != "" {
+		req.Header.Set("Authorization", "Bearer "+p.token)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("github request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github unexpected status: %d", resp.StatusCode)
+	}
+
+	var payload githubSearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("github decode: %w", err)
+	}
+
+	results := make([]models.SearchResult, 0, len(payload.Items))
+	now := time.Now().UTC()
+	for _, item := range payload.Items {
+		results = append(results, models.SearchResult{
+			Title:     item.Name,
+			Snippet:   item.Description,
+			URL:       item.HTMLURL,
+			Source:    p.Name(),
+			Timestamp: now,
+		})
+	}
+
+	return results, nil
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,0 +1,13 @@
+package provider
+
+import (
+	"context"
+
+	"kshanik_search/internal/models"
+)
+
+// SearchProvider describes providers that can search a remote data source.
+type SearchProvider interface {
+	Search(ctx context.Context, query string) ([]models.SearchResult, error)
+	Name() string
+}

--- a/internal/provider/wikipedia.go
+++ b/internal/provider/wikipedia.go
@@ -1,0 +1,74 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"kshanik_search/internal/models"
+)
+
+type WikipediaProvider struct {
+	client     *http.Client
+	baseURL    string
+	maxResults int
+}
+
+func NewWikipediaProvider(client *http.Client, baseURL string, maxResults int) *WikipediaProvider {
+	return &WikipediaProvider{client: client, baseURL: baseURL, maxResults: maxResults}
+}
+
+func (p *WikipediaProvider) Name() string { return "wikipedia" }
+
+func (p *WikipediaProvider) Search(ctx context.Context, query string) ([]models.SearchResult, error) {
+	endpoint := fmt.Sprintf("%s/w/api.php?action=opensearch&search=%s&limit=%d&namespace=0&format=json", p.baseURL, url.QueryEscape(query), p.maxResults)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("wikipedia build request: %w", err)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("wikipedia request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("wikipedia unexpected status: %d", resp.StatusCode)
+	}
+
+	var payload []interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("wikipedia decode: %w", err)
+	}
+	if len(payload) < 4 {
+		return nil, nil
+	}
+
+	titles, _ := payload[1].([]interface{})
+	descriptions, _ := payload[2].([]interface{})
+	links, _ := payload[3].([]interface{})
+
+	results := make([]models.SearchResult, 0, p.maxResults)
+	now := time.Now().UTC()
+	for i := 0; i < len(links) && i < p.maxResults; i++ {
+		u, _ := links[i].(string)
+		if u == "" {
+			continue
+		}
+		title, _ := titles[i].(string)
+		snippet, _ := descriptions[i].(string)
+		results = append(results, models.SearchResult{
+			Title:     title,
+			Snippet:   snippet,
+			URL:       u,
+			Source:    p.Name(),
+			Timestamp: now,
+		})
+	}
+
+	return results, nil
+}

--- a/internal/service/ranking.go
+++ b/internal/service/ranking.go
@@ -1,0 +1,8 @@
+package service
+
+import "kshanik_search/internal/models"
+
+// AdvancedRanker is reserved for future BM25/vector hybrid ranking logic.
+type AdvancedRanker interface {
+	Rank(query string, input []models.SearchResult) ([]models.SearchResult, error)
+}

--- a/internal/service/search_service.go
+++ b/internal/service/search_service.go
@@ -1,0 +1,75 @@
+package service
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+
+	"kshanik_search/internal/models"
+	"kshanik_search/internal/provider"
+)
+
+type SearchService struct {
+	providers []provider.SearchProvider
+}
+
+func NewSearchService(providers []provider.SearchProvider) *SearchService {
+	return &SearchService{providers: providers}
+}
+
+func (s *SearchService) Search(ctx context.Context, query string) ([]models.SearchResult, error) {
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		results []models.SearchResult
+	)
+
+	for _, p := range s.providers {
+		p := p
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			providerResults, err := p.Search(ctx, query)
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			results = append(results, providerResults...)
+			mu.Unlock()
+		}()
+	}
+
+	wg.Wait()
+	results = dedupeByURL(results)
+	results = applySimpleRanking(results)
+	return results, nil
+}
+
+func dedupeByURL(input []models.SearchResult) []models.SearchResult {
+	seen := make(map[string]struct{}, len(input))
+	output := make([]models.SearchResult, 0, len(input))
+	for _, item := range input {
+		key := strings.TrimSpace(strings.ToLower(item.URL))
+		if key == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		output = append(output, item)
+	}
+	return output
+}
+
+func applySimpleRanking(results []models.SearchResult) []models.SearchResult {
+	weights := map[string]float64{"duckduckgo": 1.0, "wikipedia": 0.95, "github": 0.9}
+	for i := range results {
+		results[i].Score = weights[results[i].Source] - float64(i)*0.01
+	}
+	sort.SliceStable(results, func(i, j int) bool {
+		return results[i].Score > results[j].Score
+	})
+	return results
+}


### PR DESCRIPTION
### Motivation

- Replace the existing verbose Spring Boot backend with a smaller, idiomatic Go service for search aggregation.
- Provide a concurrent meta-search layer that fans out to multiple third-party sources and simplifies orchestration.
- Make the architecture ready to integrate a crawler, classical inverted index, and vector-ranking in future iterations.

### Description

- Add a Go composition root and HTTP server at `cmd/server/main.go` and an API handler providing `GET /search?q=` with context-aware timeouts and JSON responses in `internal/api`.
- Introduce a normalized `SearchResult` model and a `SearchProvider` interface to enable pluggable providers under `internal/models` and `internal/provider`.
- Implement DuckDuckGo, Wikipedia, and GitHub providers using `net/http`, context propagation, request timeouts, JSON parsing, and normalization into `SearchResult` objects.
- Implement `SearchService` that calls providers concurrently with goroutines + `sync.WaitGroup`, then deduplicates results by URL and applies a simple score-based ranking, and add stubs for `crawler`, `index`, and `AdvancedRanker` to allow future extensions.

### Testing

- Ran formatting with `gofmt -w` across the new files which completed successfully.
- Ran `go test ./...` which completed successfully (packages contain no test files at this stage).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b2a11d7448333a30b8ebef4355459)